### PR TITLE
Add config file for issue templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
This should enable one of the templates to be chosen when creating a new issue; right now clicking 'new issue' works normally.