### PR TITLE
[EDIT] Minor Typo in codebook text, node H.2

### DIFF
--- a/nodes/H.2/Lesson.md
+++ b/nodes/H.2/Lesson.md
@@ -159,7 +159,7 @@ Assuming the condition $\langle \psi_0\vert U^\dagger U\vert \psi_0\rangle = 1$,
 (a) Show that $\langle \psi_0\vert U^\dagger U\vert \psi_0\rangle = 1$ implies
 
 $$
-\Re[\alpha^*\beta \langle\mathbf{x}\vert U^\dagger U\vert \mathbf{x}\rangle] = 0,
+\Re[\alpha^*\beta \langle\mathbf{x}\vert U^\dagger U\vert \mathbf{x'}\rangle] = 0,
 $$
 
 where $\Re$ denotes the real component of a complex number.


### PR DESCRIPTION
Exercise H.2.3(a):

## Current
![image](https://user-images.githubusercontent.com/70229100/144718174-58c97936-13b5-4d45-b42b-2313e722dc58.png)

Underlined portion should be |x'> and not |x>

## Proposed fix
Just switch |x> to |x'>.

## Background info
![image](https://user-images.githubusercontent.com/70229100/144718256-d52d7ccf-86a4-404e-b2e9-7ab5c3eb5e55.png)
