### PR TITLE
Fixed typo in instructions to nodes/H.6.1b/challengeDescription.md

### DIFF
--- a/nodes/H.6.1b/challengeDescription.md
+++ b/nodes/H.6.1b/challengeDescription.md
@@ -1,3 +1,3 @@
-(b) Complete the code below to apply the sum $X + Z$ to the state $\vert 0\rangle$ (on the main register). You can invoke ``add_two_unitaries(U, V)`` from the last challenge, and access the matrix form of the Paulis using, e.g., ``qml.PauliX.matrix``.
+(b) Complete the code below to apply the sum $X + Z$ to the state $\vert 0\rangle$ (on the main register). You can invoke ``add_two_unitaries(U, V)`` from the last challenge, and access the matrix form of the Paulis using, e.g., ``qml.PauliX.compute_matrix()``.
 
 Note that $X + Z \propto H$. Are the results what you expect?


### PR DESCRIPTION
Changed the instructions in nodes/H.6.1b/challengeDescription.md from… qml.PauliX.matrix  to qml.PauliX.compute_matrix()
The former is not supported as static method.

Issue is described here: https://github.com/XanaduAI/Xanadu-Quantum-Codebook/issues/55#issue-1589935857